### PR TITLE
Fix description of ```regexp```

### DIFF
--- a/docs/en/config/routing.md
+++ b/docs/en/config/routing.md
@@ -98,7 +98,7 @@ Currently, only the option `"field"` is supported.
 An array where each item is a domain match. There are several forms:
 
 - Plain string: If this string matches any part of the target domain, the rule takes effect. For example, "sina.com" can match "sina.com", "sina.com.cn", and "www.sina.com", but not "sina.cn".
-- Regular expression: Starts with `"regexp:"` followed by a regular expression. When this regular expression matches the target domain, the rule takes effect. For example, "regexp:\\.goo.\*\\.com$" matches "www.google.com" or "fonts.googleapis.com", but not "google.com".
+- Regular expression: Starts with `"regexp:"` followed by a regular expression. When this regular expression matches the target domain, the rule takes effect. For example, "regexp:\\\\.goo.\*\\\\.com$" matches "www.google.com" or "fonts.googleapis.com", but not "google.com".
 - Subdomain (recommended): Starts with `"domain:"` followed by a domain. When this domain is the target domain or a subdomain of the target domain, the rule takes effect. For example, "domain:xray.com" matches "www.xray.com" and "xray.com", but not "wxray.com".
 - Exact match: Starts with `"full:"` followed by a domain. When this domain is an exact match for the target domain, the rule takes effect. For example, "full:xray.com" matches "xray.com" but not "www.xray.com".
 - Predefined domain list: Starts with `"geosite:"` followed by a name such as `geosite:google` or `geosite:cn`. The names and domain lists are listed in [Predefined Domain List](#predefined-domain-list).


### PR DESCRIPTION
The markdown processor also treats the ```\``` as a escape character.
Markdown 也会把 ```\``` 作为转义字符。